### PR TITLE
Integration test

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -26,7 +26,7 @@ fn it_works() -> BoxResult {
 
 fn init(dir: &TempDir) -> BoxResult {
     let mut rmob = Command::cargo_bin("rmob")?;
-    rmob.current_dir(dir.path()).arg("init").assert().success();
+    rmob.current_dir(dir.path()).arg("embark").assert().success();
     let hook = dir.path().join(".git/hooks/").join(HOOK_NAME);
     assert!(hook.exists());
 


### PR DESCRIPTION
Ahoy! `git2` commits didn' honor th' hooks, so had t' use th' good ole git command line instead!