### PR TITLE
Implement commands to manipulate ~/.git-copirates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,9 @@ Includes `Co-authored by` lines in commits for ye automatically when ye collabor
 
 1. `git clone` this ship
 1. `cargo build` and `cargo install --path .` for now
-1. Add a `~/.git-copirates` file like this
-    ```json
-    {
-      "copirates": {
-        "cb": {
-          "name": "Charlotte de Berry",
-          "email": "berrydeath@england.pir"
-        }
-      }
-    }
-
+1. Add co-pirates by running:
+    ```bash
+    rmob copirate add cb "Charlotte de Berry" "berrydeath@england.pir"
     ```
 1. In your repo, `rmob embark`
 1. `rmob sail` away!
@@ -32,13 +24,17 @@ Rmob 0.1.0
 Arr! Git mobbing in Rust
 
 USAGE:
-    rmob <SUBCOMMAND>
+    rmob [OPTIONS] <SUBCOMMAND>
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
 
+OPTIONS:
+        --git-copirates-file <git_copirates_file>     [env: GIT_COPIRATES_FILE=]  [default: .git-copirates]
+
 SUBCOMMANDS:
+    copirate              Edit copirates list
     embark                Embark on rmob fer this git repo, call this once t' use rmob in yer git repo
     help                  Prints this message or the help of the given subcommand(s)
     prepare-commit-msg    Called from the git hook only

--- a/src/copirate.rs
+++ b/src/copirate.rs
@@ -56,20 +56,20 @@ impl CoPirates {
     }
 
     /// Adds copirate by alias
-    pub fn add(&mut self, initials: &str, copirate: CoPirate) -> BoxResult<()> {
-        if !self.copirates.contains_key(initials) {
-            self.copirates.insert(initials.to_owned(), copirate);
+    pub fn add(&mut self, alias: &str, copirate: CoPirate) -> BoxResult<()> {
+        if !self.copirates.contains_key(alias) {
+            self.copirates.insert(alias.to_owned(), copirate);
             Ok(())
         } else {
-            Err(format!("Co-pirate with alias '{}' already exists", initials).into())
+            Err(format!("Co-pirate with alias '{}' already exists", alias).into())
         }
     }
 
     /// Removes existing copirate
-    pub fn remove(&mut self, initials: &str) -> BoxResult<()> {
+    pub fn remove(&mut self, alias: &str) -> BoxResult<()> {
         self.copirates
-            .remove(initials)
-            .ok_or(format!("Co-pirate with alias '{}' is not found!", initials))?;
+            .remove(alias)
+            .ok_or(format!("Co-pirate with alias '{}' is not found!", alias))?;
         Ok(())
     }
 
@@ -83,7 +83,7 @@ impl CoPirates {
 
 /// Adds copirate with specific credentials to copirates file. Creates new copirates file if it
 /// didn't exist before. Won't add another copirate with the same alias
-pub(crate) fn add(copirates_file: &str, initials: &str, name: &str, email: &str) -> BoxResult<()> {
+pub(crate) fn add(copirates_file: &str, alias: &str, name: &str, email: &str) -> BoxResult<()> {
     let ship = dirs::home_dir().ok_or("Could not find yer ship oy!")?;
     let copirates_path = &ship.join(copirates_file);
     let mut existing_copirates = CoPirates::create_or_open(copirates_path)?;
@@ -92,19 +92,19 @@ pub(crate) fn add(copirates_file: &str, initials: &str, name: &str, email: &str)
         name: name.to_owned(),
         email: email.to_owned(),
     };
-    existing_copirates.add(initials, copirate)?;
+    existing_copirates.add(alias, copirate)?;
     existing_copirates.save(copirates_path)?;
 
     Ok(())
 }
 
 /// Removes existing copirate by their alias from the copirates file
-pub(crate) fn remove(copirates_file: &str, initials: &str) -> BoxResult<()> {
+pub(crate) fn remove(copirates_file: &str, alias: &str) -> BoxResult<()> {
     let ship = dirs::home_dir().ok_or("Could not find yer ship oy!")?;
     let copirates_path = &ship.join(copirates_file);
     let mut existing_copirates = CoPirates::open(copirates_path)?;
 
-    existing_copirates.remove(initials)?;
+    existing_copirates.remove(alias)?;
     existing_copirates.save(copirates_path)?;
 
     Ok(())

--- a/src/copirate.rs
+++ b/src/copirate.rs
@@ -51,7 +51,7 @@ impl CoPirates {
 
     /// Returns the details of the given co-author, if known.
     pub fn get(&self, copirate: &String) -> BoxResult<&CoPirate> {
-        let copirate = self.copirates.get(copirate).ok_or("Shiver me timbers! This be pirate be a stranger around these ports. Hint: Add it to ~/.git-copirates!")?;
+        let copirate = self.copirates.get(copirate).ok_or("Shiver me timbers! This be pirate be a stranger around these ports. Hint: run `rmob copirate add --help`")?;
         Ok(copirate)
     }
 

--- a/src/copirate.rs
+++ b/src/copirate.rs
@@ -5,12 +5,12 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::fs;
 use std::path::Path;
 
-use serde::Deserialize;
+use serde::{Serialize, Deserialize};
 
 use crate::BoxResult;
 
 /// Represents the details of a single co-author.
-#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct CoPirate {
     pub name: String,
     pub email: String,
@@ -23,12 +23,23 @@ impl Display for CoPirate {
 }
 
 /// Configuration file which assigns convenient two-letter aliases to co-authors.
-#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct CoPirates {
     copirates: HashMap<String, CoPirate>,
 }
 
 impl CoPirates {
+    /// Creates an empty copirates file if it doesn't exist.
+    /// Otherwise, opens the existing one.
+    pub fn create_or_open(copirates_path: &Path) -> BoxResult<CoPirates> {
+        if !copirates_path.exists() {
+            let empty_copirates = CoPirates { copirates: HashMap::new() };
+            empty_copirates.save(copirates_path)?;
+        }
+
+        Self::open(copirates_path)
+    }
+
     /// Parses the given co-authors file as JSON.
     pub fn open(copirates_path: &Path) -> BoxResult<CoPirates> {
         let raw_copirates = fs::read_to_string(copirates_path)?;
@@ -41,6 +52,55 @@ impl CoPirates {
         let copirate = self.copirates.get(copirate).ok_or("Shiver me timbers! This be pirate be a stranger around these ports. Hint: Add it to ~/.git-copirates!")?;
         Ok(copirate)
     }
+
+    /// Adds copirate by alias
+    pub fn add(&mut self, initials: &str, copirate: CoPirate) -> BoxResult<()> {
+        if !self.copirates.contains_key(initials) {
+            self.copirates.insert(initials.to_owned(), copirate);
+            Ok(())
+        } else {
+            Err(format!("Co-pirate with alias '{}' already exists", initials).into())
+        }
+    }
+
+    /// Removes existing copirate
+    pub fn remove(&mut self, initials: &str) -> BoxResult<()> {
+        self.copirates.remove(initials).ok_or(format!("Co-pirate with alias '{}' is not found!", initials))?;
+        Ok(())
+    }
+
+    /// Saves copirates into file
+    pub fn save(&self, copirates_path: &Path) -> BoxResult<()> {
+        let json = serde_json::to_string(self)?;
+        fs::write(copirates_path, json.as_bytes())?;
+        Ok(())
+    }
+}
+
+/// Adds copirate with specific credentials to copirates file. Creates new copirates file if it
+/// didn't exist before. Won't add another copirate with the same alias
+pub(crate) fn add(copirates_file: &str, initials: &str, name: &str, email: &str) -> BoxResult<()> {
+    let ship = dirs::home_dir().ok_or("Could not find yer ship oy!")?;
+    let copirates_path = &ship.join(copirates_file);
+    let mut existing_copirates = CoPirates::create_or_open(copirates_path)?;
+
+    let copirate = CoPirate { name: name.to_owned(), email: email.to_owned() };
+    existing_copirates.add(initials, copirate)?;
+    existing_copirates.save(copirates_path)?;
+
+    Ok(())
+}
+
+/// Removes existing copirate by their alias from the copirates file
+pub(crate) fn remove(copirates_file: &str, initials: &str) -> BoxResult<()> {
+    let ship = dirs::home_dir().ok_or("Could not find yer ship oy!")?;
+    let copirates_path = &ship.join(copirates_file);
+    let mut existing_copirates = CoPirates::open(copirates_path)?;
+
+    existing_copirates.remove(initials)?;
+    existing_copirates.save(copirates_path)?;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/copirate.rs
+++ b/src/copirate.rs
@@ -5,7 +5,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::fs;
 use std::path::Path;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use crate::BoxResult;
 
@@ -33,7 +33,9 @@ impl CoPirates {
     /// Otherwise, opens the existing one.
     pub fn create_or_open(copirates_path: &Path) -> BoxResult<CoPirates> {
         if !copirates_path.exists() {
-            let empty_copirates = CoPirates { copirates: HashMap::new() };
+            let empty_copirates = CoPirates {
+                copirates: HashMap::new(),
+            };
             empty_copirates.save(copirates_path)?;
         }
 
@@ -65,7 +67,9 @@ impl CoPirates {
 
     /// Removes existing copirate
     pub fn remove(&mut self, initials: &str) -> BoxResult<()> {
-        self.copirates.remove(initials).ok_or(format!("Co-pirate with alias '{}' is not found!", initials))?;
+        self.copirates
+            .remove(initials)
+            .ok_or(format!("Co-pirate with alias '{}' is not found!", initials))?;
         Ok(())
     }
 
@@ -84,7 +88,10 @@ pub(crate) fn add(copirates_file: &str, initials: &str, name: &str, email: &str)
     let copirates_path = &ship.join(copirates_file);
     let mut existing_copirates = CoPirates::create_or_open(copirates_path)?;
 
-    let copirate = CoPirate { name: name.to_owned(), email: email.to_owned() };
+    let copirate = CoPirate {
+        name: name.to_owned(),
+        email: email.to_owned(),
+    };
     existing_copirates.add(initials, copirate)?;
     existing_copirates.save(copirates_path)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,22 @@ struct Rmob {
 }
 
 #[derive(StructOpt, Clone, Debug)]
+enum CopirateSubcommand {
+    /// Adds a co-pirate to the list
+    #[structopt(name = "add")]
+    Add {
+        initials: String,
+        name: String,
+        email: String,
+    },
+    /// Removes co-pirate from the list
+    #[structopt(name = "remove")]
+    Remove {
+        initials: String,
+    },
+}
+
+#[derive(StructOpt, Clone, Debug)]
 enum Command {
     /// Embark on rmob fer this git repo, call this once t' use rmob in yer git repo
     #[structopt(name = "embark")]
@@ -44,6 +60,12 @@ enum Command {
     /// Sail solo (short fer `rmob sail solo`)
     #[structopt(name = "solo")]
     Solo,
+    /// Edit copirates list
+    #[structopt(name = "copirate")]
+    Copirate {
+        #[structopt(subcommand)]
+        cmd: CopirateSubcommand
+    },
     /// Called from the git hook only
     #[structopt(name = "prepare-commit-msg")]
     PrepareCommitMessage {
@@ -65,6 +87,13 @@ pub fn run() -> BoxResult<()> {
         Command::Solo => solo::solo(repo_dir)?,
         Command::Sail { ref copirates } if copirates == &["solo"] => solo::solo(repo_dir)?,
         Command::Sail { ref copirates } => sail::sail(&copirates_file, copirates, repo_dir)?,
+        Command::Copirate { ref cmd } => {
+            match cmd {
+                CopirateSubcommand::Add { ref initials, ref name, ref email } => copirate::add(&copirates_file, initials, name, email)?,
+                CopirateSubcommand::Remove { ref initials } => copirate::remove(&copirates_file, initials)?,
+            };
+        }
+
         Command::PrepareCommitMessage {
             commit_message_file,
         } => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,13 +37,13 @@ enum CopirateSubcommand {
     /// Adds a co-pirate to the list
     #[structopt(name = "add")]
     Add {
-        initials: String,
+        alias: String,
         name: String,
         email: String,
     },
     /// Removes co-pirate from the list
     #[structopt(name = "remove")]
-    Remove { initials: String },
+    Remove { alias: String },
 }
 
 #[derive(StructOpt, Clone, Debug)]
@@ -88,12 +88,12 @@ pub fn run() -> BoxResult<()> {
         Command::Copirate { ref cmd } => {
             match cmd {
                 CopirateSubcommand::Add {
-                    ref initials,
+                    ref alias,
                     ref name,
                     ref email,
-                } => copirate::add(&copirates_file, initials, name, email)?,
-                CopirateSubcommand::Remove { ref initials } => {
-                    copirate::remove(&copirates_file, initials)?
+                } => copirate::add(&copirates_file, alias, name, email)?,
+                CopirateSubcommand::Remove { ref alias } => {
+                    copirate::remove(&copirates_file, alias)?
                 }
             };
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,7 @@ enum CopirateSubcommand {
     },
     /// Removes co-pirate from the list
     #[structopt(name = "remove")]
-    Remove {
-        initials: String,
-    },
+    Remove { initials: String },
 }
 
 #[derive(StructOpt, Clone, Debug)]
@@ -64,7 +62,7 @@ enum Command {
     #[structopt(name = "copirate")]
     Copirate {
         #[structopt(subcommand)]
-        cmd: CopirateSubcommand
+        cmd: CopirateSubcommand,
     },
     /// Called from the git hook only
     #[structopt(name = "prepare-commit-msg")]
@@ -89,8 +87,14 @@ pub fn run() -> BoxResult<()> {
         Command::Sail { ref copirates } => sail::sail(&copirates_file, copirates, repo_dir)?,
         Command::Copirate { ref cmd } => {
             match cmd {
-                CopirateSubcommand::Add { ref initials, ref name, ref email } => copirate::add(&copirates_file, initials, name, email)?,
-                CopirateSubcommand::Remove { ref initials } => copirate::remove(&copirates_file, initials)?,
+                CopirateSubcommand::Add {
+                    ref initials,
+                    ref name,
+                    ref email,
+                } => copirate::add(&copirates_file, initials, name, email)?,
+                CopirateSubcommand::Remove { ref initials } => {
+                    copirate::remove(&copirates_file, initials)?
+                }
             };
         }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3,7 +3,6 @@ use std::process::Command;
 use assert_cmd::prelude::*;
 use git2::{Commit, ObjectType, Repository};
 use rmob::*;
-use std::fs;
 use tempfile::{tempdir, TempDir};
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -13,7 +13,7 @@ fn it_works() -> BoxResult<()> {
 
     embark(&dir)?;
 
-    init_git_copirates(&dir)?;
+    add_new_copirate(&dir)?;
 
     sail(&dir)?;
 
@@ -38,20 +38,18 @@ fn embark(dir: &TempDir) -> BoxResult<()> {
     Ok(())
 }
 
-fn init_git_copirates(dir: &TempDir) -> BoxResult<()> {
-    let copirates = r#"
-        {
-          "copirates": {
-            "cb": {
-              "name": "Charlotte de Berry",
-              "email": "berrydeath@england.pir"
-            }
-          }
-        }
-    "#;
-    let copirates_file = dir.path().join(".git-copirates");
-
-    fs::write(copirates_file, copirates)?;
+fn add_new_copirate(dir: &TempDir) -> BoxResult<()> {
+    let mut rmob = Command::cargo_bin("rmob")?;
+    rmob.current_dir(dir.path())
+        .arg("--git-copirates-file")
+        .arg(dir.path().join(".git-copirates"))
+        .arg("copirate")
+        .arg("add")
+        .arg("cb")
+        .arg("'Charlotte de Berry'")
+        .arg("'berrydeath@england.pir'")
+        .assert()
+        .success();
 
     Ok(())
 }


### PR DESCRIPTION
```
USAGE:
    rmob copirate <SUBCOMMAND>

SUBCOMMANDS:
    add       Adds a co-pirate to the list
    remove    Removes co-pirate from the list
```

Add:

```
Adds a co-pirate to the list

USAGE:
    rmob copirate add <alias> <name> <email>

ARGS:
    <alias>
    <name>
    <email>
```

Remove:

```
Removes co-pirate from the list

USAGE:
    rmob copirate remove <alias>

ARGS:
    <alias>
```

Closes #21.