### PR TITLE
Make the git hook platform agnostic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         rust-version: [1.37.0, beta, nightly]
         include:
           - rust-version: nightly

--- a/src/embark.rs
+++ b/src/embark.rs
@@ -1,5 +1,6 @@
 //! Subcommand for initializing `rmob` with the given Git repository.
 
+#[cfg(not(windows))]
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
 use std::{fs, io::Result as IoResult};


### PR DESCRIPTION
Resolves #5, I think.

What has been done in this PR::
* Conditional compilation check with `#[cfg(windows)]` for Windows